### PR TITLE
Automate version bump process

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ Shortcodes:
 Test: create page with shortcode, submit a quote, confirm CPT `ppb_quote` is created.
 
 Handover pack attached in repo.
+
+## Release
+
+The plugin version is defined in `package.json`.
+
+1. Run `npm version <newversion>` to bump the version. This runs `bin/bump-version.sh` which updates `party-plan-builder.php` and README references.
+2. Build the ZIP archive:
+   `zip -r party-plan-builder-$(node -p "require('./package.json').version").zip party-plan-builder`
+3. Upload the ZIP to WordPress or distribute as needed.

--- a/bin/bump-version.sh
+++ b/bin/bump-version.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION=$(node -p "require('${ROOT_DIR}/package.json').version")
+
+PHP_FILE="$ROOT_DIR/party-plan-builder/party-plan-builder.php"
+README="$ROOT_DIR/README.md"
+
+# Update plugin header version
+sed -i -E "s/(\* Version: )[0-9]+\.[0-9]+\.[0-9]+/\1$VERSION/" "$PHP_FILE"
+# Update enqueued script version
+sed -i -E "s/(wp_register_script\('ppb-script', false, \['jquery'\], ')[0-9]+\.[0-9]+\.[0-9]+('\))/\1$VERSION\2/" "$PHP_FILE"
+
+# Update README references
+sed -i -E "s/(party-plan-builder v)[0-9]+\.[0-9]+\.[0-9]+/\1$VERSION/" "$README"
+sed -i -E "s/(party-plan-builder-)[0-9]+\.[0-9]+\.[0-9]+(\.zip)/\1$VERSION\2/" "$README"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "party-plan-builder",
+  "version": "1.6.1",
+  "scripts": {
+    "version": "bin/bump-version.sh"
+  }
+}


### PR DESCRIPTION
## Summary
- centralize version in `package.json`
- add `bin/bump-version.sh` script to propagate version to plugin and docs
- document `npm version`-based release workflow

## Testing
- `npm run version`

------
https://chatgpt.com/codex/tasks/task_e_68c53d7a1c14832d9214d3e6fd1d98e6